### PR TITLE
Fix flatten permission for numeric authitem name

### DIFF
--- a/components/AuthBehavior.php
+++ b/components/AuthBehavior.php
@@ -291,13 +291,13 @@ class AuthBehavior extends CBehavior
             if (isset($itemPermissions['children'])) {
                 $children = $itemPermissions['children'];
                 unset($itemPermissions['children']); // not needed in a flat tree
-                $flattened = array_merge($flattened, $this->flattenPermissions($children));
+                $flattened = $flattened + $this->flattenPermissions($children);
             }
 
             if (isset($itemPermissions['parents'])) {
                 $parents = $itemPermissions['parents'];
                 unset($itemPermissions['parents']);
-                $flattened = array_merge($flattened, $this->flattenPermissions($parents));
+                $flattened = $flattened + $this->flattenPermissions($parents);
             }
         }
         return $flattened;


### PR DESCRIPTION
Julian Egelstaff at php dot net: In some situations, the union operator ( + ) might be more useful to you than array_merge.  The array_merge function does not preserve numeric key values.  If you need to preserve the numeric keys, then using + will do that.
